### PR TITLE
Two performance improvements to read/correctLPJmL

### DIFF
--- a/R/correctLPJmL.R
+++ b/R/correctLPJmL.R
@@ -18,16 +18,28 @@ correctLPJmL <- function(x, subtype) {
   # Special case: for monthly NPP negative values should be kept and
   # only be corrected after aggregation to yearly values (see calcLPJmLTransform)
   if (!grepl("npp", subtype)) {
-    toolExpectTrue(all(x >= -1e-10), "Data provided by LPJmL is not negative",
+    # min(x) >= -1e-10 is equivalent to all(x >= -1e-10) but short-circuits
+    # a full elementwise comparison into a single reduction, which matters
+    # on multi-GB LPJmL objects. NA is handled the same way as before: since
+    # NA is never isTRUE(), a not-yet-checked-for-NA object still correctly
+    # falls through to running the replace below.
+    noNeg <- min(x) >= -1e-10
+    toolExpectTrue(noNeg, "Data provided by LPJmL is not negative",
                    falseStatus = "warn")
-    # Correct negative values (set to zero)
-    x <- madrat::toolConditionalReplace(x, conditions = "<0", replaceby = 0)
+    # Correct negative values (set to zero) -- skip the full-object pass
+    # entirely when the check above already confirmed nothing to replace
+    if (!isTRUE(noNeg)) {
+      x <- madrat::toolConditionalReplace(x, conditions = "<0", replaceby = 0)
+    }
   }
 
-  # Check and replace N/A's
-  toolExpectTrue(all(!is.na(x)), "Data provided by LPJmL doesn't contain N/A's",
+  # Check and replace N/A's (same short-circuit reasoning as above)
+  noNA <- !anyNA(x)
+  toolExpectTrue(noNA, "Data provided by LPJmL doesn't contain N/A's",
                  falseStatus = "warn")
-  x <- toolConditionalReplace(x, conditions = c("is.na()"), replaceby = 0)
+  if (!isTRUE(noNA)) {
+    x <- toolConditionalReplace(x, conditions = c("is.na()"), replaceby = 0)
+  }
 
   # extract unit of data
   unit <- madrat::getFromComment(x, "unit")

--- a/R/readLPJmL.R
+++ b/R/readLPJmL.R
@@ -101,6 +101,12 @@ readLPJmL <- function(subtype = "lpjml5.10.0-m4:MRI-ESM2-0:ssp245:crops:sdate") 
 
   x <- mstools::toolCoord2Isocoord(x)
 
+  # No convertLPJmL() exists, so readSource("LPJmL", ...) always resolves to
+  # the "correct" prefix (both convert = TRUE, the default, and convert =
+  # "onlycorrect", which is what all current callers use) -- the read-level
+  # cache written here is never read back. Skipping it avoids gzip-writing a
+  # large object (up to several GB) to disk for nothing.
   return(list(x = x,
-              unit = unit))
+              unit = unit,
+              cache = FALSE))
 }


### PR DESCRIPTION
First one is to disable caching for `readLPJmL`, as it those cache files are never read but only the `correctLPJmL` ones.

Second performance improvement is a set of changes in `correctLPJmL` all boiling down to reducing the number of element-wise operations on the complete LPJmL object.